### PR TITLE
Fix horrible scroll hack

### DIFF
--- a/l2t-paper-slider.html
+++ b/l2t-paper-slider.html
@@ -497,7 +497,7 @@ Custom property | Description | Default
             break;
           }
         }
-        // Horrible scroll hack (don't judge me).
+        /*/ Horrible scroll hack (don't judge me).
         if (e.detail.sourceEvent.type != "mousemove") {
           switch(e.detail.state) {
             case 'start':
@@ -509,6 +509,7 @@ Custom property | Description | Default
             break;
           }
         }
+        */
       },
 
       // Public //
@@ -572,6 +573,9 @@ Custom property | Description | Default
         setTimeout(function(){
           this$._moveManual();
         }, 0);
+
+        //allow vertical scrolling
+        this.setScrollDirection('y', this.$.container);
       },
     });
   })();


### PR DESCRIPTION
The horrible scroll hack creates scroll lag on mobile and disables scrolling momentum. Polymer has a function to allow scrolling in a certain direction when listening to track events.